### PR TITLE
OpenShift compatibility

### DIFF
--- a/.prod/nginx.conf
+++ b/.prod/nginx.conf
@@ -1,3 +1,9 @@
+client_body_temp_path /tmp/client_temp;
+proxy_temp_path       /tmp/proxy_temp_path;
+fastcgi_temp_path     /tmp/fastcgi_temp;
+uwsgi_temp_path       /tmp/uwsgi_temp;
+scgi_temp_path        /tmp/scgi_temp;
+
 server {
     listen       8080;
     server_name  localhost;

--- a/.prod/nginx.conf
+++ b/.prod/nginx.conf
@@ -1,5 +1,5 @@
 server {
-    listen       80;
+    listen       8080;
     server_name  localhost;
 
     location /healthz {

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ RUN yarn build
 FROM nginx:1.17 as production
 # =============================
 
-USER root
+#USER root
 
 #RUN chgrp -R 0 /usr/share/nginx/html && \
 #    chmod -R g=u /usr/share/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,8 +68,8 @@ FROM nginx:1.17 as production
 
 USER root
 
-RUN chgrp -R 0 /usr/share/nginx/html && \
-    chmod -R g=u /usr/share/nginx/html
+#RUN chgrp -R 0 /usr/share/nginx/html && \
+#    chmod -R g=u /usr/share/nginx/html
     
 #RUN chgrp -R 0 /var/cache/nginx && \
 #    chmod -R g=u /var/cache/nginx

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,9 @@ COPY --from=staticbuilder /app/build /usr/share/nginx/html
 # Copy nginx config
 COPY .prod/nginx.conf /etc/nginx/conf.d/default.conf
 
+#for running as non-root
+RUN echo "pid        /tmp/nginx.pid;" >> /etc/nginx/nginx.conf
+
 CMD ["/bin/bash", "-c", "nginx -g \"daemon off;\""]
 
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,7 @@ RUN chgrp -R 0 /usr/share/nginx/html && \
     
 RUN chgrp -R 0 /var/cache/nginx && \
     chmod -R g=u /var/cache/nginx
+RUN chmod 777 /var/cache/nginx
 
 # Copy static build
 COPY --from=staticbuilder /app/build /usr/share/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,15 +66,6 @@ RUN yarn build
 FROM nginx:1.17 as production
 # =============================
 
-#USER root
-
-#RUN chgrp -R 0 /usr/share/nginx/html && \
-#    chmod -R g=u /usr/share/nginx/html
-    
-#RUN chgrp -R 0 /var/cache/nginx && \
-#    chmod -R g=u /var/cache/nginx
-#RUN chmod 777 /var/cache/nginx
-
 # Copy static build
 COPY --from=staticbuilder /app/build /usr/share/nginx/html
 
@@ -83,7 +74,5 @@ COPY .prod/nginx.conf /etc/nginx/conf.d/default.conf
 
 #for running as non-root
 RUN sed -i 's/\/var\/run\/nginx.pid/\/tmp\/nginx.pid/g' /etc/nginx/nginx.conf
-
-#CMD ["/bin/bash", "-c", "nginx -g \"daemon off;\""]
 
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,13 +28,13 @@ ENV PATH /app/node_modules/.bin:$PATH
 
 USER root
 
-RUN apt-install.sh build-essential
+RUN bash /tools/apt-install.sh build-essential
 
 USER appuser
 RUN yarn && yarn cache clean --force
 
 USER root
-RUN apt-cleanup.sh build-essential
+RUN bash /tools/apt-cleanup.sh build-essential
 
 # =============================
 FROM appbase as development
@@ -66,9 +66,17 @@ RUN yarn build
 FROM nginx:1.17 as production
 # =============================
 
-# Nginx runs with user "nginx" by default
-COPY --from=staticbuilder --chown=nginx:nginx /app/build /usr/share/nginx/html
+USER root
 
-COPY .prod/nginx.conf /etc/nginx/conf.d/default.conf
+RUN chgrp -R 0 /usr/share/nginx/html && \
+    chmod -R g=u /usr/share/nginx/html
 
-EXPOSE 80
+# Copy static build
+COPY --from=staticbuilder /app/build /usr/share/nginx/html
+
+# Copy nginx config
+COPY .prod/nginx.conf  /etc/nginx/
+
+CMD ["/bin/bash", "-c", "nginx -g \"daemon off;\""]
+
+EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ RUN chgrp -R 0 /usr/share/nginx/html && \
 COPY --from=staticbuilder /app/build /usr/share/nginx/html
 
 # Copy nginx config
-COPY .prod/nginx.conf  /etc/nginx/
+COPY .prod/nginx.conf /etc/nginx/conf.d/default.conf
 
 CMD ["/bin/bash", "-c", "nginx -g \"daemon off;\""]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ COPY --from=staticbuilder /app/build /usr/share/nginx/html
 COPY .prod/nginx.conf /etc/nginx/conf.d/default.conf
 
 #for running as non-root
-RUN echo "pid        /tmp/nginx.pid;" >> /etc/nginx/nginx.conf
+RUN sed -i 's/\/var\/run\/nginx.pid/\/tmp\/nginx.pid/g' /etc/nginx/nginx.conf
 
 CMD ["/bin/bash", "-c", "nginx -g \"daemon off;\""]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,9 +71,9 @@ USER root
 RUN chgrp -R 0 /usr/share/nginx/html && \
     chmod -R g=u /usr/share/nginx/html
     
-RUN chgrp -R 0 /var/cache/nginx && \
-    chmod -R g=u /var/cache/nginx
-RUN chmod 777 /var/cache/nginx
+#RUN chgrp -R 0 /var/cache/nginx && \
+#    chmod -R g=u /var/cache/nginx
+#RUN chmod 777 /var/cache/nginx
 
 # Copy static build
 COPY --from=staticbuilder /app/build /usr/share/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,6 @@ COPY .prod/nginx.conf /etc/nginx/conf.d/default.conf
 #for running as non-root
 RUN sed -i 's/\/var\/run\/nginx.pid/\/tmp\/nginx.pid/g' /etc/nginx/nginx.conf
 
-CMD ["/bin/bash", "-c", "nginx -g \"daemon off;\""]
+#CMD ["/bin/bash", "-c", "nginx -g \"daemon off;\""]
 
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,8 +66,8 @@ RUN yarn build
 FROM nginx:1.17 as production
 # =============================
 
-# Copy static build
-COPY --from=staticbuilder /app/build /usr/share/nginx/html
+# Nginx runs with user "nginx" by default
+COPY --from=staticbuilder --chown=nginx:nginx /app/build /usr/share/nginx/html
 
 # Copy nginx config
 COPY .prod/nginx.conf /etc/nginx/conf.d/default.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,9 @@ USER root
 
 RUN chgrp -R 0 /usr/share/nginx/html && \
     chmod -R g=u /usr/share/nginx/html
+    
+RUN chgrp -R 0 /var/cache/nginx && \
+    chmod -R g=u /var/cache/nginx
 
 # Copy static build
 COPY --from=staticbuilder /app/build /usr/share/nginx/html


### PR DESCRIPTION
Modifications required for running (and building) with OpenShift. Most notably the exposed port must not be a privileged port - changed it to 8080