### PR TITLE
Move eslint files to dependencies to prevent compile error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-ui-profile",
-  "version": "0.7",
+  "version": "0.7.1",
   "license": "MIT",
   "private": true,
   "dependencies": {
@@ -19,7 +19,12 @@
     "await-handler": "^1.1.2",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",
+    "eslint": "^7.15.0",
     "eslint-config-airbnb-typescript-prettier": "^4.1.0",
+    "eslint-config-prettier": "^6.4.0",
+    "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-prettier": "^3.1.1",
+    "eslint-plugin-sonarjs": "^0.5.0",
     "graphql": "^15.4.0",
     "graphql.macro": "^1.4.2",
     "hds-core": "0.13.2",
@@ -64,11 +69,6 @@
   },
   "devDependencies": {
     "@testing-library/react": "^11.0.4",
-    "eslint": "^7.15.0",
-    "eslint-config-prettier": "^6.4.0",
-    "eslint-plugin-import": "^2.22.1",
-    "eslint-plugin-prettier": "^3.1.1",
-    "eslint-plugin-sonarjs": "^0.5.0",
     "jest-environment-jsdom-sixteen": "^1.0.3",
     "jest-fetch-mock": "3.0.3",
     "jest-sonar-reporter": "^2.0.0",


### PR DESCRIPTION
Fix same compile error in Docker as Profiili UI had after upgrading to react-scripts v4. The new version some how messes up environment var and devDependencies for linting are not found. Moved them to dependencies.