### PR TITLE
HP-617: Added new scope

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,6 @@
+REACT_APP_OIDC_URL="https://tunnistamo.dev.hel.ninja"
+REACT_APP_OIDC_CLIENT_ID="exampleapp-ui"
+REACT_APP_PROFILE_BACKEND_URL="https://helsinki-profile-api-dev.agw.arodevtest.hel.fi/graphql/"
+REACT_APP_OIDC_SCOPE="openid profile https://api.hel.fi/auth/helsinkiprofile https://api.hel.fi/auth/exampleapp"
+REACT_APP_OIDC_CALLBACK_PATH="/callback/"
 REACT_APP_PROFILE_UI_URL="https://helsinki-profile-ui-dev.agw.arodevtest.hel.fi"


### PR DESCRIPTION
New scope for dev and test environments: https://api.hel.fi/auth/exampleapp

.env (production config) uses https://api.hel.fi/sso-test as OIDC end-point. New scope is not added to that end-point and not added to that config.

.env.development now includes config for https://tunnistamo.dev.hel.ninja end-point and also new scope and other configs so example works with that endpoint.

Returned api-token for new scope can be seen on /apiAccessTokens page.