### PR TITLE
HP-629: Remove useless link

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -85,12 +85,6 @@ const Header = (): React.ReactElement => {
             onSignIn={(): void => client.login()}
             userName={userName}>
             <Navigation.Item
-              label={userName}
-              href="https://hel.fi"
-              target="_blank"
-              variant="primary"
-            />
-            <Navigation.Item
               as="a"
               href={`${config.ui.profileUIUrl}/loginsso`}
               label="Helsinki-profiili"


### PR DESCRIPTION
Link with user name was obsolete now that there is link to Profile.