### PR TITLE
HP-732: poll session from backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "hds-core": "0.21.0",
     "hds-design-tokens": "0.21.0",
     "hds-react": "0.21.0",
+    "http-status-typed": "^1.0.0",
     "jwt-decode": "^3.0.0",
     "oidc-client": "1.11.5",
     "react": "^16.11.0",

--- a/src/client/__mocks__/http-poller.ts
+++ b/src/client/__mocks__/http-poller.ts
@@ -1,0 +1,43 @@
+import { GlobalWithFetchMock } from 'jest-fetch-mock';
+import { HttpPoller, HttpPollerProps } from '../http-poller';
+
+type MockHttpPollerData = {
+  start: jest.Mock;
+  stop: jest.Mock;
+  props?: HttpPollerProps;
+};
+
+type GlobalWithPollerData = GlobalWithFetchMock & {
+  mockHttpPoller: MockHttpPollerData;
+};
+
+const globalWithPollerData = global as GlobalWithPollerData;
+
+if (!globalWithPollerData.mockHttpPoller) {
+  globalWithPollerData.mockHttpPoller = {
+    start: jest.fn(),
+    stop: jest.fn(),
+    props: undefined
+  };
+}
+const { mockHttpPoller } = globalWithPollerData;
+
+export function getHttpPollerMockData(): MockHttpPollerData {
+  return mockHttpPoller;
+}
+
+export default function createHttpPoller(
+  pollerProps: HttpPollerProps
+): HttpPoller {
+  mockHttpPoller.start.mockReset();
+  mockHttpPoller.stop.mockReset();
+  mockHttpPoller.props = pollerProps;
+  return {
+    start: () => {
+      mockHttpPoller.start();
+    },
+    stop: () => {
+      mockHttpPoller.stop();
+    }
+  };
+}

--- a/src/client/__tests__/http-poller.test.ts
+++ b/src/client/__tests__/http-poller.test.ts
@@ -1,0 +1,193 @@
+import HttpStatusCode from 'http-status-typed';
+import createHttpPoller, { HttpPoller } from '../http-poller';
+
+type TestProps = {
+  requestResponse: {
+    status: HttpStatusCode.OK | HttpStatusCode.FORBIDDEN | -1;
+  };
+  onErrorReturnValue: { keepPolling: boolean };
+  shouldPollReturnValue: boolean;
+  maxPollCount: number;
+};
+
+jest.unmock('../http-poller');
+
+describe(`http-poller`, () => {
+  const pollFunctionMockCallback = jest.fn();
+  const onErrorMockCallback = jest.fn();
+  const shouldPollMockCallback = jest.fn();
+  const loadCallTracker = jest.fn();
+  const intervalInMs = 200;
+  let poller: HttpPoller;
+  const pollerDefaultTestProps: TestProps = {
+    requestResponse: { status: HttpStatusCode.OK },
+    onErrorReturnValue: { keepPolling: true },
+    shouldPollReturnValue: true,
+    maxPollCount: 0
+  };
+  function createPoller(responses: TestProps): HttpPoller {
+    let pollCount = 0;
+    return createHttpPoller({
+      pollFunction: async () => {
+        pollFunctionMockCallback();
+        return new Promise((resolve, reject) => {
+          setTimeout(() => {
+            loadCallTracker();
+            if (responses.requestResponse.status === -1) {
+              reject(new Error('An error'));
+            } else {
+              resolve(responses.requestResponse as Response);
+            }
+          }, intervalInMs * 2);
+        });
+      },
+      onError: returnedHttpStatus => {
+        onErrorMockCallback(returnedHttpStatus);
+        return responses.onErrorReturnValue;
+      },
+      shouldPoll: () => {
+        shouldPollMockCallback();
+        if (responses.maxPollCount > 0 && pollCount >= responses.maxPollCount) {
+          return false;
+        }
+        pollCount += 1;
+        return responses.shouldPollReturnValue;
+      },
+      pollIntervalInMs: intervalInMs
+    });
+  }
+  const advanceOneInterval = async () => {
+    jest.advanceTimersByTime(intervalInMs + 1);
+  };
+  const advanceToTimerEnd = async () => {
+    await advanceOneInterval();
+  };
+  const advanceFromTimerEndToLoadEnd = async () => {
+    await advanceOneInterval();
+    await advanceOneInterval();
+    // https://stackoverflow.com/questions/52177631/jest-timer-and-promise-dont-work-well-settimeout-and-async-function
+    await new Promise(resolve => setImmediate(resolve));
+  };
+  const advanceFromStartTimerToLoadEnd = async () => {
+    await advanceToTimerEnd();
+    await advanceFromTimerEndToLoadEnd();
+  };
+  const advanceFromTimerEndToNextTimerEnd = async () => {
+    await advanceFromTimerEndToLoadEnd();
+    await advanceToTimerEnd();
+  };
+  afterEach(() => {
+    poller.stop();
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  describe('Calling start() starts the timer and when timer ends ', () => {
+    it('the pollFunction and shouldPoll have been called continuously', async () => {
+      poller = createPoller({
+        ...pollerDefaultTestProps
+      });
+      poller.start();
+      expect(shouldPollMockCallback).not.toBeCalled();
+      expect(pollFunctionMockCallback).not.toBeCalled();
+      expect(onErrorMockCallback).not.toBeCalled();
+      await advanceToTimerEnd();
+      expect(shouldPollMockCallback).toHaveBeenCalledTimes(1);
+      expect(pollFunctionMockCallback).toHaveBeenCalledTimes(1);
+      await advanceFromTimerEndToNextTimerEnd();
+      expect(shouldPollMockCallback).toHaveBeenCalledTimes(2);
+      expect(pollFunctionMockCallback).toHaveBeenCalledTimes(2);
+      expect(loadCallTracker).toHaveBeenCalledTimes(1);
+      expect(onErrorMockCallback).toHaveBeenCalledTimes(0);
+    });
+    it('the pollFunction should not be called if shouldPoll returns false', async () => {
+      poller = createPoller({
+        ...pollerDefaultTestProps,
+        shouldPollReturnValue: false
+      });
+      poller.start();
+      await advanceToTimerEnd();
+      expect(shouldPollMockCallback).toHaveBeenCalledTimes(1);
+      expect(pollFunctionMockCallback).toHaveBeenCalledTimes(0);
+      await advanceToTimerEnd();
+      expect(shouldPollMockCallback).toHaveBeenCalledTimes(2);
+      expect(pollFunctionMockCallback).toHaveBeenCalledTimes(0);
+    });
+    it('the onError is called with responseStatus when response status is not httpStatus.OK (200). Polling continues when onError returns {keepPolling : true}', async () => {
+      poller = createPoller({
+        ...pollerDefaultTestProps,
+        requestResponse: { status: HttpStatusCode.FORBIDDEN }
+      });
+      poller.start();
+      await advanceFromStartTimerToLoadEnd();
+      expect(shouldPollMockCallback).toHaveBeenCalledTimes(1);
+      expect(onErrorMockCallback).toHaveBeenCalledTimes(1);
+      expect(onErrorMockCallback).toBeCalledWith(HttpStatusCode.FORBIDDEN);
+      await advanceToTimerEnd();
+      expect(shouldPollMockCallback).toHaveBeenCalledTimes(2);
+    });
+    it('the onError is called also on network error and polling stops after error when onError returns {keepPolling : false}', async () => {
+      poller = createPoller({
+        ...pollerDefaultTestProps,
+        requestResponse: { status: -1 },
+        onErrorReturnValue: { keepPolling: false }
+      });
+      poller.start();
+      await advanceFromStartTimerToLoadEnd();
+      expect(onErrorMockCallback).toHaveBeenCalledTimes(1);
+      expect(onErrorMockCallback).toBeCalledWith(undefined);
+      expect(shouldPollMockCallback).toHaveBeenCalledTimes(1);
+      expect(pollFunctionMockCallback).toHaveBeenCalledTimes(1);
+      await advanceToTimerEnd();
+      expect(shouldPollMockCallback).toHaveBeenCalledTimes(1);
+      expect(pollFunctionMockCallback).toHaveBeenCalledTimes(1);
+    });
+    it('Polling never starts if poller.stop is called', async () => {
+      poller = createPoller({
+        ...pollerDefaultTestProps
+      });
+      poller.start();
+      poller.stop();
+      await advanceFromStartTimerToLoadEnd();
+      expect(shouldPollMockCallback).toHaveBeenCalledTimes(0);
+      expect(pollFunctionMockCallback).toHaveBeenCalledTimes(0);
+      expect(loadCallTracker).toHaveBeenCalledTimes(0);
+    });
+    it('Response is ignored if poller.stop is called after load has started', async () => {
+      poller = createPoller({
+        ...pollerDefaultTestProps,
+        requestResponse: { status: HttpStatusCode.FORBIDDEN }
+      });
+      poller.start();
+      await advanceToTimerEnd();
+      expect(shouldPollMockCallback).toHaveBeenCalledTimes(1);
+      expect(pollFunctionMockCallback).toHaveBeenCalledTimes(1);
+      poller.stop();
+      await advanceFromTimerEndToLoadEnd();
+      expect(loadCallTracker).toHaveBeenCalledTimes(1);
+      expect(onErrorMockCallback).toHaveBeenCalledTimes(0);
+      expect(shouldPollMockCallback).toHaveBeenCalledTimes(1);
+      expect(pollFunctionMockCallback).toHaveBeenCalledTimes(1);
+    });
+    it('Multiple starts do not start multiple requests', async () => {
+      poller = createPoller({
+        ...pollerDefaultTestProps,
+        requestResponse: { status: HttpStatusCode.FORBIDDEN }
+      });
+      poller.start();
+      poller.start();
+      poller.start();
+      await advanceToTimerEnd();
+      expect(shouldPollMockCallback).toHaveBeenCalledTimes(1);
+      expect(pollFunctionMockCallback).toHaveBeenCalledTimes(1);
+      poller.stop();
+      await advanceFromTimerEndToLoadEnd();
+      expect(onErrorMockCallback).toHaveBeenCalledTimes(0);
+      expect(shouldPollMockCallback).toHaveBeenCalledTimes(1);
+      expect(pollFunctionMockCallback).toHaveBeenCalledTimes(1);
+      expect(loadCallTracker).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/client/http-poller.ts
+++ b/src/client/http-poller.ts
@@ -1,0 +1,84 @@
+import to from 'await-to-js';
+import HttpStatusCode from 'http-status-typed';
+
+export type HttpPoller = {
+  start: () => void;
+  stop: () => void;
+};
+
+export type HttpPollerProps = {
+  pollFunction: () => Promise<Response | undefined>;
+  shouldPoll: () => boolean;
+  onError: (returnedHttpStatus?: number) => { keepPolling: boolean };
+  pollIntervalInMs?: number;
+};
+
+const defaultPollIntervalInMs = 60000;
+
+export default function createHttpPoller({
+  pollFunction,
+  shouldPoll,
+  onError,
+  pollIntervalInMs = defaultPollIntervalInMs
+}: HttpPollerProps): HttpPoller {
+  let isPolling = false;
+  let isForceStopped = false;
+  let pollTimeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  const load = async (): Promise<[Error | null, Response | undefined]> => {
+    isPolling = true;
+    const result = await to(pollFunction());
+    isPolling = false;
+    return result;
+  };
+
+  const shouldCallPollFunction = (): boolean => {
+    if (isPolling) {
+      return false;
+    }
+    return shouldPoll();
+  };
+
+  const startTimer = () => {
+    if (pollTimeoutId) {
+      clearTimeout(pollTimeoutId);
+    }
+    pollTimeoutId = setTimeout(() => {
+      pollTimeoutId = undefined;
+      if (!shouldCallPollFunction()) {
+        startTimer();
+        return;
+      }
+      // eslint-disable-next-line @typescript-eslint/no-use-before-define
+      pollAndHandleResult();
+    }, pollIntervalInMs);
+  };
+
+  const pollAndHandleResult = async (): Promise<void> => {
+    const [err, data] = await load();
+    if (isForceStopped) {
+      return;
+    }
+    const responseStatus = data && data.status;
+    const isErrorResponse = responseStatus !== HttpStatusCode.OK;
+    if ((!err && !isErrorResponse) || onError(responseStatus).keepPolling) {
+      startTimer();
+    }
+  };
+
+  const stop = () => {
+    if (pollTimeoutId) {
+      clearTimeout(pollTimeoutId);
+      pollTimeoutId = undefined;
+    }
+    isForceStopped = true;
+  };
+
+  return {
+    start: () => {
+      isForceStopped = false;
+      startTimer();
+    },
+    stop
+  };
+}

--- a/src/components/ErrorPrompt.tsx
+++ b/src/components/ErrorPrompt.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Notification } from 'hds-react';
 
-import { useClientErrorDetection } from '../client/hooks';
+import { useClientErrorDetection, useClient } from '../client/hooks';
 import { ClientErrorObject, ClientError } from '../client';
 import styles from './styles.module.css';
 
@@ -12,6 +12,7 @@ const ErrorPrompt = (
     undefined
   );
   const newError = useClientErrorDetection();
+  const client = useClient();
   const lastErrorType = dismissedError && dismissedError.type;
   const newErrorType = newError && newError.type;
   if (lastErrorType === newErrorType) {
@@ -26,13 +27,19 @@ const ErrorPrompt = (
           <Notification
             label="Error"
             type="error"
-            onClose={(): void => setDismissedError(newError)}
+            onClose={(): void => {
+              setDismissedError(newError);
+              if (sessionEndedElsewhere) {
+                client.logout();
+              }
+            }}
             dismissible
             closeButtonLabelText="Sulje">
             {sessionEndedElsewhere ? (
               <p>
                 Käyttäjän sessio on päättynyt ilman uloskirjautumista tässä
-                ikkunassa
+                selainikkunassa. <br /> <br /> Sinut kirjataan ulos myös tästä,
+                kun suljet tämän ilmoituksen.
               </p>
             ) : (
               <>

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -42,3 +42,5 @@ jest.mock('oidc-client', () => {
     UserManager: MockUserManagerClass
   };
 });
+
+jest.mock('./client/http-poller');

--- a/yarn.lock
+++ b/yarn.lock
@@ -6651,6 +6651,11 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+http-status-typed@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/http-status-typed/-/http-status-typed-1.0.0.tgz#2dbf0a036a7c5e4c0447fa22bc8f42f0221b9481"
+  integrity sha512-pDW3/qUMd9IRxJ7WLizQbD2EY6qp/Zf5FB96gIbNoz9QuxdY5LAEl/z4eNQX2p/cKYKngaUNTqmQ1XgLwi/bhg==
+
 https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"


### PR DESCRIPTION
User's session is polled every 60 seconds by calling "/userinfo"-endpoint. Polling is started, when user is logged in and stopped when user logs out. 

If BE does not respond with status 200, the poller calls "onError"-callback and the response is handled in the client. When a previously authenticated user gets a status 401 / 403 response, an error is raised and used will be logged out in the UI too.

Currently Tunnistamo won't kill sessions properly (userinfo keeps sending 200), so manual testing can only be done with Tunnistus.