### PR TITLE
Moved jest-fetch-mock to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "hds-design-tokens": "0.21.0",
     "hds-react": "0.21.0",
     "http-status-typed": "^1.0.0",
+    "jest-fetch-mock": "3.0.3",
     "jwt-decode": "^3.0.0",
     "oidc-client": "1.11.5",
     "react": "^16.11.0",
@@ -70,7 +71,6 @@
   "devDependencies": {
     "@testing-library/react": "^11.0.4",
     "jest-environment-jsdom-sixteen": "^1.0.3",
-    "jest-fetch-mock": "3.0.3",
     "jest-sonar-reporter": "^2.0.0",
     "mocked-env": "^1.3.2",
     "prettier": "^1.18.2",


### PR DESCRIPTION
Same problem used to be in Profile UI and now introduced via first test file using __mocks__ -folder. Without this an error is thrown when building docker image: Cannot find module 'jest-fetch-mock'