### PR TITLE
Increase yarn timeout in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ USER root
 RUN bash /tools/apt-install.sh build-essential
 
 USER appuser
+RUN yarn config set network-timeout 300000
 RUN yarn && yarn cache clean --force
 
 USER root


### PR DESCRIPTION
Build fails in Azure stage pipeline with ESOCKETTIMEDOUT when running yarn command.

Issue is discussed here https://github.com/yarnpkg/yarn/issues/8242

Same change was already done in profile UI