### PR TITLE
HP-506: use runtime variables

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -30,7 +30,7 @@
     "sonarjs/prefer-immediate-return": "error",
     "sonarjs/no-duplicate-string": "error",
     "import/no-namespace": "error",
-    "no-underscore-dangle": ["error", { "allow": ["__typename"] }]
+    "no-underscore-dangle": ["error", { "allow": ["__typename", "_env_"] }]
   },
   "globals": {
     "cy": true

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ yarn-debug.log*
 yarn-error.log*
 .vscode
 .eslintcache
+
+public/env-config.js
+public/test-env-config.js

--- a/.prod/nginx.conf
+++ b/.prod/nginx.conf
@@ -1,28 +1,39 @@
-client_body_temp_path /tmp/client_temp;
-proxy_temp_path       /tmp/proxy_temp_path;
-fastcgi_temp_path     /tmp/fastcgi_temp;
-uwsgi_temp_path       /tmp/uwsgi_temp;
-scgi_temp_path        /tmp/scgi_temp;
+pid        /tmp/nginx.pid; #for running as non-root 
 
-server {
-    listen       8080;
-    server_name  localhost;
+events {
+    worker_connections  4096;  ## Default: 1024
+}
+http {
+    #for running as non-root
+    client_body_temp_path /tmp/client_temp;
+    proxy_temp_path       /tmp/proxy_temp_path;
+    fastcgi_temp_path     /tmp/fastcgi_temp;
+    uwsgi_temp_path       /tmp/uwsgi_temp;
+    scgi_temp_path        /tmp/scgi_temp;
+    
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+    
+    server {
+        listen       8080;
+        server_name  localhost;
 
-    location /healthz {
-        return 200 'OK';
-    }
+        location /healthz {
+            return 200 'OK';
+        }
 
-    location /readiness {
-        return 200 'OK';
-    }
+        location /readiness {
+            return 200 'OK';
+        }
 
-    location / {
-        root   /usr/share/nginx/html;
-        try_files $uri /index.html;
-    }
+        location / {
+            root   /usr/share/nginx/html;
+            try_files $uri /index.html;
+        }
 
-    error_page   500 502 503 504  /50x.html;
-    location = /50x.html {
-        root   /usr/share/nginx/html;
-    }
+        error_page   500 502 503 504  /50x.html;
+        location = /50x.html {
+            root   /usr/share/nginx/html;
+        }
+    }        
 }

--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ Config can also be overridden for command line:
 REACT_APP_OIDC_URL=https://foo.bar yarn start
 ```
 
+### Environment variables
+
+Scripts generates first environment variables to `public/env-config.js` with `scripts/update-runtime-env.ts`, which contains the
+actual used variables when running the app. App is not using CRA's default `process.env` way to refer of variables but
+`window._env_` object.
+
+Note that running built application locally you need to generate also `public/env-config.js` file. It can be done with
+`yarn update-runtime-env`. By default it's generated for development environment if no `NODE_ENV` is set.
+
 ### Config for Helsinki-Profiili MVP
 
 Settings when using Helsinki-Profiili MVP authentication:
@@ -86,7 +95,11 @@ services:
 
 ### yarn test
 
-Runs tests in watch mode
+Runs tests in watch mode.
+
+Scripts generates first environment variables to `public/test-env-config.js` with `scripts/update-runtime-env.ts`, which contains the
+actual used variables when running the app. App is not using CRA's default `process.env` way to refer of variables but
+`window._env_` object.
 
 ### yarn test-coverage
 

--- a/README.md
+++ b/README.md
@@ -77,10 +77,27 @@ REACT_APP_PROFILE_AUDIENCE="https://api.hel.fi/auth/helsinkiprofile"
 
 ## Docker
 
-Run `docker-compose up`
+Docker image has ".env"-file baked in, so it uses production environment variables by default. To make the image work in other environments, env vars must be overridden.
 
-Starting docker with temporary environment variables:
-Open docker-compose.yml and add new 'environment' under services/app.
+You can pass new env vars easily with '--env-file' argument. Of course '-e' works too.
+
+### Docker run
+
+```
+docker run --env-file=.env.development -p 3000:8080 helsinki/example-ui-profile
+```
+
+### Docker compose
+
+Note that the composed build will stop to the 'development' stage in Dockerfile and uses 'react-scripts start' command and not nginx.
+
+The env-file is fixed to '.env.development" in the 'docker-compose.yml'.
+
+```
+docker compose up
+```
+
+Env vars can be overridden in the yaml-file.
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -96,3 +96,11 @@ Runs tests with coverage outputted to console. Results are saved to /coverage No
 
 Runs tests with coverage and its results are saved as an xml file by jest-sonar-reporter.
 This file can be sent to Sonar with Sonar Scanner (CLI). Report is /reports
+
+### yarn update-runtime-env
+
+Generates variable object used when app is running. Generated object is stored at `public/env-config.js` and available
+as `window._env_` object.
+
+Generation uses `react-scripts` internals, so values come from either environment variables or files (according
+[react-scripts documentation](https://create-react-app.dev/docs/adding-custom-environment-variables/#what-other-env-files-can-be-used)).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,4 +12,5 @@ services:
     ports:
       - '3000:3000'
     stdin_open: true
-  
+    env_file:
+      - .env.development

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-ui-profile",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "license": "MIT",
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "http-status-typed": "^1.0.0",
     "jest-fetch-mock": "3.0.3",
     "jwt-decode": "^3.0.0",
-    "mocked-env": "^1.3.2",
     "oidc-client": "1.11.5",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",

--- a/package.json
+++ b/package.json
@@ -46,12 +46,12 @@
     "typescript": "^4.4.4"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "yarn run update-runtime-env && react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "cross-env TEST=true yarn run update-runtime-env && react-scripts test",
     "test-coverage": "CI=true yarn test --coverage",
     "test-coverage-for-sonar": "yarn test-coverage --testResultsProcessor jest-sonar-reporter",
-    "ci": "CI=true yarn test --coverage",
+    "ci": "cross-env CI=true yarn test --coverage",
     "lint": "eslint --ext js,ts,tsx src",
     "update-runtime-env": "ts-node -P ./scripts/tsconfig.json --files scripts/update-runtime-env.ts"
   },
@@ -74,7 +74,8 @@
     "@testing-library/react": "^11.0.4",
     "jest-sonar-reporter": "^2.0.0",
     "prettier": "^1.18.2",
-    "ts-node": "^8.8.2"
+    "ts-node": "^8.8.2",
+    "cross-env": "^7.0.3"
   },
   "jest": {
     "transformIgnorePatterns": [

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "test-coverage": "CI=true yarn test --coverage",
     "test-coverage-for-sonar": "yarn test-coverage --testResultsProcessor jest-sonar-reporter",
     "ci": "CI=true yarn test --coverage",
-    "lint": "eslint --ext js,ts,tsx src"
+    "lint": "eslint --ext js,ts,tsx src",
+    "update-runtime-env": "ts-node -P ./scripts/tsconfig.json --files scripts/update-runtime-env.ts"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,7 @@
       content="Rekisteröitymällä Helsingin kaupungin uusiin palveluihin, sinulle luodaan Helsinki-profiili, jonka kautta näet vaivattomasti tietosi, joita sinusta keräämme sekä palvelut joihin olet tunnistautunut."
     />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <script src="%PUBLIC_URL%/env-config.js"></script>
     <title>Example UI</title>
   </head>
   <body>

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+ENVDIR=${1:-.}
+TARGETDIR=${2:-.}
+# Recreate config file
+rm -f $TARGETDIR/env-config.js
+touch $TARGETDIR/env-config.js
+
+REACT_APP_VERSION=$(grep -m1 version $ENVDIR/package.json | awk -F: '{ print $2 }' | sed 's/[", ]//g')
+REACT_APP_APPLICATION_NAME=$(grep -m1 name $ENVDIR/package.json | awk -F: '{ print $2 }' | sed 's/[", ]//g')
+
+# Add assignment
+echo "window._env_ = {" >> $TARGETDIR/env-config.js
+
+# Read each line in .env file
+# Each line represents key=value pairs
+while read -r line || [[ -n "$line" ]];
+do
+  # Split env variables by character `=`
+  if printf '%s\n' "$line" | grep -q -e '='; then
+    varname=$(printf '%s\n' "$line" | sed -e 's/=.*//')
+    varvalue=$(printf '%s\n' "$line" | sed -e 's/^[^=]*=//')
+  fi
+
+  # Read value of current variable if exists as Environment variable
+  value=$(printf '%s\n' "${!varname}")
+  # Otherwise use value from .env file
+  [[ -z $value ]] && value=${varvalue}
+  #Remove quotes around the value to make it easier to use value
+  value=${value%\"}
+  value=${value#\"}
+  # Append configuration property to JS file
+  echo "  $varname: \"$(echo ${value} | envsubst)\"," >> $TARGETDIR/env-config.js
+
+  # Store value to current subshell to allow usage of it at later values
+  export $varname="$(echo ${value} | envsubst)"
+done < $ENVDIR/.env
+
+echo "}" >> $TARGETDIR/env-config.js

--- a/scripts/update-runtime-env.ts
+++ b/scripts/update-runtime-env.ts
@@ -1,0 +1,40 @@
+#!/usr/bin/env ts-node-script
+
+import * as path from 'path';
+import fs from 'fs';
+import util from 'util';
+
+// react-scipts config requires ENV to be set
+const defaultNodeEnv = process.env.TEST ? 'test' : 'development';
+// Prevent collision is app is running while tests are started
+const configFile = process.env.TEST ? 'test-env-config.js' : 'env-config.js';
+
+process.env.NODE_ENV = process.env.NODE_ENV || defaultNodeEnv;
+
+const getClientEnvironment = require('../node_modules/react-scripts/config/env.js');
+
+const configurationFile: string = path.join(
+  __dirname,
+  '../public/' + configFile
+);
+
+const start = async () => {
+  try {
+    const envVariables = getClientEnvironment();
+    fs.writeFile(
+      configurationFile,
+      'window._env_ = ' + util.inspect(envVariables.raw, false, 2, false),
+      function(err) {
+        if (err) {
+          return console.error(err);
+        }
+        return console.log('File created!');
+      }
+    );
+  } catch (err) {
+    console.error(err.message); // eslint-disable-line
+    process.exit(1);
+  }
+};
+
+start();

--- a/src/apiAccessTokens/useApiAccessTokens.ts
+++ b/src/apiAccessTokens/useApiAccessTokens.ts
@@ -86,9 +86,9 @@ export function useApiAccessTokens(): ApiAccessTokenActions {
         return;
       }
       fetchTokens({
-        audience: String(process.env.REACT_APP_API_BACKEND_AUDIENCE),
-        permission: String(process.env.REACT_APP_API_BACKEND_PERMISSION),
-        grantType: String(process.env.REACT_APP_API_BACKEND_GRANT_TYPE)
+        audience: String(window._env_.REACT_APP_API_BACKEND_AUDIENCE),
+        permission: String(window._env_.REACT_APP_API_BACKEND_PERMISSION),
+        grantType: String(window._env_.REACT_APP_API_BACKEND_GRANT_TYPE)
       });
     };
 

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -14,7 +14,7 @@ type Request = AuthorizedRequest<ReturnData, FetchProps>;
 export type BackendActions = AuthorizedApiActions<ReturnData, FetchProps>;
 
 export function getBackendApiToken(apiTokens: JWTPayload): string | undefined {
-  const tokenKey = process.env.REACT_APP_BACKEND_AUDIENCE;
+  const tokenKey = window._env_.REACT_APP_BACKEND_AUDIENCE;
   if (!tokenKey) {
     return undefined;
   }
@@ -40,7 +40,7 @@ export const executeAPIAction: Request = async options => {
     Error | null,
     Response | undefined
   ] = await to(
-    fetch(process.env.REACT_APP_BACKEND_URL as string, requestOptions)
+    fetch(window._env_.REACT_APP_BACKEND_URL as string, requestOptions)
   );
   if (fetchError || !fetchResponse) {
     throw new Error('Network or CORS error occured');

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,30 +22,30 @@ function envValueToBoolean(
 function createConfigFromEnv(
   source: 'OIDC' | 'PLAIN_SUOMIFI'
 ): Partial<ClientConfig> {
-  const url = String(process.env[`REACT_APP_${source}_URL`]);
-  const realm = String(process.env[`REACT_APP_${source}_REALM`]);
+  const url = String(window._env_[`REACT_APP_${source}_URL`]);
+  const realm = String(window._env_[`REACT_APP_${source}_REALM`]);
   const tokenExchangePath =
-    process.env[`REACT_APP_${source}_TOKEN_EXCHANGE_PATH`];
+    window._env_[`REACT_APP_${source}_TOKEN_EXCHANGE_PATH`];
   return {
     realm,
     url,
     authority: realm ? `${url}/realms/${realm}` : url,
-    clientId: String(process.env[`REACT_APP_${source}_CLIENT_ID`]),
-    callbackPath: String(process.env[`REACT_APP_${source}_CALLBACK_PATH`]),
-    logoutPath: process.env[`REACT_APP_${source}_LOGOUT_PATH`] || '/',
-    silentAuthPath: process.env[`REACT_APP_${source}_SILENT_AUTH_PATH`],
-    responseType: process.env[`REACT_APP_${source}_RESPONSE_TYPE`],
-    scope: process.env[`REACT_APP_${source}_SCOPE`],
+    clientId: String(window._env_[`REACT_APP_${source}_CLIENT_ID`]),
+    callbackPath: String(window._env_[`REACT_APP_${source}_CALLBACK_PATH`]),
+    logoutPath: window._env_[`REACT_APP_${source}_LOGOUT_PATH`] || '/',
+    silentAuthPath: window._env_[`REACT_APP_${source}_SILENT_AUTH_PATH`],
+    responseType: window._env_[`REACT_APP_${source}_RESPONSE_TYPE`],
+    scope: window._env_[`REACT_APP_${source}_SCOPE`],
     autoSignIn: envValueToBoolean(
-      process.env[`REACT_APP_${source}_AUTO_SIGN_IN`],
+      window._env_[`REACT_APP_${source}_AUTO_SIGN_IN`],
       true
     ),
     automaticSilentRenew: envValueToBoolean(
-      process.env[`REACT_APP_${source}_AUTO_SILENT_RENEW`],
+      window._env_[`REACT_APP_${source}_AUTO_SILENT_RENEW`],
       true
     ),
     enableLogging: envValueToBoolean(
-      process.env[`REACT_APP_${source}_LOGGING`],
+      window._env_[`REACT_APP_${source}_LOGGING`],
       false
     ),
     tokenExchangePath,
@@ -60,7 +60,7 @@ const mvpConfig = {
 } as ClientConfig;
 
 const uiConfig: { profileUIUrl: string } = {
-  profileUIUrl: String(process.env.REACT_APP_PROFILE_UI_URL)
+  profileUIUrl: String(window._env_.REACT_APP_PROFILE_UI_URL)
 };
 
 const plainSuomiFiConfig = {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,15 +8,22 @@ import BrowserApp from './BrowserApp';
 // eslint-disable-next-line import/no-namespace
 import * as serviceWorker from './serviceWorker';
 
+declare global {
+  interface Window {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    _env_: any;
+  }
+}
+
 const ENVS_WITH_SENTRY = ['staging', 'production'];
 
 if (
-  process.env.REACT_APP_ENVIRONMENT &&
-  ENVS_WITH_SENTRY.includes(process.env.REACT_APP_ENVIRONMENT)
+  window._env_.REACT_APP_ENVIRONMENT &&
+  ENVS_WITH_SENTRY.includes(window._env_.REACT_APP_ENVIRONMENT)
 ) {
   Sentry.init({
-    dsn: process.env.REACT_APP_SENTRY_DSN,
-    environment: process.env.REACT_APP_ENVIRONMENT
+    dsn: window._env_.REACT_APP_SENTRY_DSN,
+    environment: window._env_.REACT_APP_ENVIRONMENT
   });
 }
 

--- a/src/pages/ApiAccessTokens.tsx
+++ b/src/pages/ApiAccessTokens.tsx
@@ -19,9 +19,9 @@ const AuthenticatedContent = (): React.ReactElement => {
     FetchApiTokenOptions,
     (newOptions: FetchApiTokenOptions) => void
   ] = useState({
-    audience: process.env.REACT_APP_API_BACKEND_AUDIENCE || '',
-    permission: process.env.REACT_APP_API_BACKEND_PERMISSION || '',
-    grantType: process.env.REACT_APP_API_BACKEND_GRANT_TYPE || ''
+    audience: window._env_.REACT_APP_API_BACKEND_AUDIENCE || '',
+    permission: window._env_.REACT_APP_API_BACKEND_PERMISSION || '',
+    grantType: window._env_.REACT_APP_API_BACKEND_GRANT_TYPE || ''
   });
   const onSubmit = async (): Promise<void> => {
     if (isLoading) {

--- a/src/profile/profile.ts
+++ b/src/profile/profile.ts
@@ -39,7 +39,7 @@ export type ProfileActions = AuthorizedApiActions<ReturnData, FetchProps>;
 
 export function getProfileGqlClient(token?: string): GraphQLClient | undefined {
   if (!profileGqlClient) {
-    const uri = process.env.REACT_APP_PROFILE_BACKEND_URL;
+    const uri = window._env_.REACT_APP_PROFILE_BACKEND_URL;
     if (!token || !uri) {
       return undefined;
     }
@@ -110,7 +110,7 @@ export async function getProfileData(
 }
 
 export function getProfileApiToken(apiTokens: JWTPayload): string | undefined {
-  const tokenKey = process.env.REACT_APP_PROFILE_AUDIENCE;
+  const tokenKey = window._env_.REACT_APP_PROFILE_AUDIENCE;
   if (!tokenKey) {
     return undefined;
   }

--- a/src/serviceWorker.ts
+++ b/src/serviceWorker.ts
@@ -26,7 +26,7 @@ type Config = {
 };
 
 export function register(config?: Config) {
-  if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
+  if (window._env_.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
     // The URL constructor is available in all browsers that support SW.
     const publicUrl = new URL(
       (process as { env: { [key: string]: string } }).env.PUBLIC_URL,
@@ -40,7 +40,7 @@ export function register(config?: Config) {
     }
 
     window.addEventListener('load', () => {
-      const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
+      const swUrl = `${window._env_.PUBLIC_URL}/service-worker.js`;
 
       if (isLocalhost) {
         // This is running on localhost. Let's check if a service worker still exists or not.

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -26,6 +26,11 @@ jest.mock('react-router', () => ({
   })
 }));
 
+jest.mock('./config', () => {
+  jest.requireActual('../public/test-env-config');
+  return jest.requireActual('./config');
+});
+
 jest.mock('oidc-client', () => {
   class MockUserManagerClass {
     constructor(settings: UserManagerSettings) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4097,6 +4097,13 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-fetch@^3.0.4:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.4.tgz#9723f3a3a247bf8b89039f3a380a9244e8fa2f39"
@@ -4104,7 +4111,7 @@ cross-fetch@^3.0.4:
   dependencies:
     node-fetch "2.6.1"
 
-cross-spawn@7.0.3, cross-spawn@^7.0.0, cross-spawn@^7.0.2:
+cross-spawn@7.0.3, cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3631,11 +3631,6 @@ char-regex@^1.0.2:
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
 
-check-more-types@2.24.0:
-  version "2.24.0"
-  resolved "https://registry.yarnpkg.com/check-more-types/-/check-more-types-2.24.0.tgz#1420ffb10fd444dcfc79b43891bbfffd32a84600"
-  integrity sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA=
-
 check-types@^11.1.1:
   version "11.1.2"
   resolved "https://registry.yarnpkg.com/check-types/-/check-types-11.1.2.tgz#86a7c12bf5539f6324eb0e70ca8896c0e38f3e2f"
@@ -4429,7 +4424,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@4.3.2, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1:
+debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
   integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
@@ -7676,11 +7671,6 @@ last-call-webpack-plugin@^3.0.0:
     lodash "^4.17.5"
     webpack-sources "^1.1.0"
 
-lazy-ass@1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/lazy-ass/-/lazy-ass-1.6.0.tgz#7999655e8646c17f089fdd187d150d3324d54513"
-  integrity sha1-eZllXoZGwX8In90YfRUNMyTVRRM=
-
 leven@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
@@ -8178,16 +8168,6 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
-
-mocked-env@^1.3.2:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/mocked-env/-/mocked-env-1.3.5.tgz#244eabdc1ed92a8f6f55a2faedc408159eb193b3"
-  integrity sha512-GyYY6ynVOdEoRlaGpaq8UYwdWkvrsU2xRme9B+WPSuJcNjh17+3QIxSYU6zwee0SbehhV6f06VZ4ahjG+9zdrA==
-  dependencies:
-    check-more-types "2.24.0"
-    debug "4.3.2"
-    lazy-ass "1.6.0"
-    ramda "0.27.1"
 
 moo@^0.5.0:
   version "0.5.1"
@@ -9932,11 +9912,6 @@ railroad-diagrams@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
   integrity sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=
-
-ramda@0.27.1:
-  version "0.27.1"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.1.tgz#66fc2df3ef873874ffc2da6aa8984658abacf5c9"
-  integrity sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==
 
 randexp@0.4.6:
   version "0.4.6"


### PR DESCRIPTION
This update mimics the same update done to Profiili UI: https://github.com/City-of-Helsinki/open-city-profile-ui/pull/131/

Basically stop using variables from process.env and use window.__env_. Those come from a js-file that is created from env vars.

Example dev and test use this branch currently.