### PR TITLE
Show email.verified on Profile page

### DIFF
--- a/src/graphql/MyProfileQuery.graphql
+++ b/src/graphql/MyProfileQuery.graphql
@@ -32,6 +32,7 @@ query MyProfileQuery {
       email
       primary
       emailType
+      verified
     }
     emails {
       edges {
@@ -40,6 +41,7 @@ query MyProfileQuery {
           id
           email
           emailType
+          verified
         }
       }
     }


### PR DESCRIPTION
Added email.verified to the graphQL query and render returned data on Profile page. 

Added so automated tests can check email was verified correctly.