### PR TITLE
ci: add dependency review workflow for pull requests

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Dependency Review
         uses: actions/dependency-review-action@v5

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,25 @@
+name: Dependency Review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v5
+        with:
+          fail-on-severity: low
+          license-check: false
+          vulnerability-check: true
+          comment-summary-in-pr: on-failure
+          show-patched-versions: true


### PR DESCRIPTION
Add GitHub Actions workflow that scans PR dependency changes for known vulnerabilities using dependency-review-action@v5. Fails on low severity and above, posts a PR comment on failure with patched version guidance.

Refs: KEH-351

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated dependency review and security vulnerability checks in the development process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->